### PR TITLE
Bumps nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## [0.1.8] - 2025-02-21
+
+- Bumps nokogiri dependency to resolve CVE-2025-24928 and CVE-2024-56171
+
 ## [0.1.5] - 2024-10-17
 
 - Improve texts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    active-record-query-count (0.1.6)
+    active-record-query-count (0.1.7)
       activesupport (>= 5.0, < 8.0)
       colorize (~> 1.1)
       launchy (~> 3.0)
-      nokogiri (~> 1.16.5)
+      nokogiri (~> 1.18.3)
 
 GEM
   remote: https://rubygems.org/
@@ -41,7 +41,7 @@ GEM
     minitest (5.24.1)
     mocha (2.4.0)
       ruby2_keywords (>= 0.0.5)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.25.1)
     parser (3.3.4.0)

--- a/active-record-query-count.gemspec
+++ b/active-record-query-count.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'activesupport', '>= 5.0', '< 8.0'
   spec.add_runtime_dependency 'colorize', '~> 1.1'
   spec.add_runtime_dependency 'launchy', '~> 3.0'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.16.5'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.18.3'
 
   spec.add_development_dependency 'activerecord', '>= 5.0', '< 8.0'
   spec.add_development_dependency 'minitest'

--- a/lib/active_record_query_count/version.rb
+++ b/lib/active_record_query_count/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordQueryCount
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
Bumps nokogiri dependency to resolve CVE-2025-24928 and CVE-2024-56171