### PR TITLE
feat: Add cached query tracking to HTML and console output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## [0.1.9] - 2025-02-23
+
+- Added cached query tracking to HTML and console output
+
 ## [0.1.8] - 2025-02-21
 
 - Bumps nokogiri dependency to resolve CVE-2025-24928 and CVE-2024-56171

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active-record-query-count (0.1.8)
+    active-record-query-count (0.1.9)
       activesupport (>= 5.0, < 8.0)
       colorize (>= 1.1, < 2)
       launchy (>= 3.0, < 4)

--- a/assets/template_base_query_counter.html.erb
+++ b/assets/template_base_query_counter.html.erb
@@ -20,6 +20,7 @@
       <th id="columnHeader">File Path</th>
       <th>Method</th>
       <th>Location Count</th>
+      <th>Cached Query</th>
       <th>Total Duration(ms)</th>
     </tr>
     <% filter_data(data).each_with_index do |(table, info), index| %>
@@ -38,6 +39,7 @@
           </td>
           <td class="method-column"><%= method %></td>
           <td><%= detail[:count] %></td>
+          <td><%= detail[:cached_query_count] %></td>
           <td><%= detail[:duration] %></td>
         </tr>
       <% end %>

--- a/lib/active_record_query_count/printer/console.rb
+++ b/lib/active_record_query_count/printer/console.rb
@@ -20,6 +20,9 @@ module ActiveRecordQueryCount
           info[:location].each do |loc, details|
             puts "    - File location: #{loc}"
             puts "        Query count: #{details[:count].to_s.colorize(:blue)}"
+            unless (details[:cached_query_count]).zero?
+              puts "        Cached: #{details[:cached_query_count].to_s.colorize(:blue)}"
+            end
             puts "        Total Duration(ms): #{details[:duration]}"
           end
           puts

--- a/lib/active_record_query_count/printer/html.rb
+++ b/lib/active_record_query_count/printer/html.rb
@@ -46,7 +46,7 @@ module ActiveRecordQueryCount
           chart_data[:labels] << table
           chart_data[:data] << info[:count]
           chart_data[:locations][table] = info[:location].map do |loc, detail|
-            { location: loc, count: detail[:count], duration: detail[:duration] }
+            { location: loc, count: detail[:count], duration: detail[:duration], cached_query_count: detail[:cached_query_count] }
           end
         end
         chart_data

--- a/lib/active_record_query_count/recording/tracker.rb
+++ b/lib/active_record_query_count/recording/tracker.rb
@@ -14,7 +14,7 @@ module ActiveRecordQueryCount
       def reset_query_count
         @active_record_query_tracker = Hash.new do |hash, key|
           hash[key] = { count: 0, location: Hash.new do |loc_hash, loc_key|
-                                              loc_hash[loc_key] = { count: 0, sql: nil }
+                                              loc_hash[loc_key] = { count: 0, sql: nil, duration: 0, cached_query_count: 0 }
                                             end }
         end
       end
@@ -25,14 +25,15 @@ module ActiveRecordQueryCount
         @subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |_a, start, finish, _d, payload|
           caller_from_sql = caller
           sql = payload[:sql]
+          cached = payload[:cached] ? 1 : 0
           match = sql.match(REGEX_TABLE_SQL)
           if match.present? && match[:table]
             actual_location = Rails.backtrace_cleaner.clean(caller_from_sql).first
             active_record_query_tracker[match[:table]][:count] += 1
-            active_record_query_tracker[match[:table]][:location][actual_location][:duration] ||= 0
             active_record_query_tracker[match[:table]][:location][actual_location][:duration] += (finish - start) * 1000
             active_record_query_tracker[match[:table]][:location][actual_location][:count] += 1
             active_record_query_tracker[match[:table]][:location][actual_location][:sql] = sql
+            active_record_query_tracker[match[:table]][:location][actual_location][:cached_query_count] += cached
           end
         end
       end

--- a/lib/active_record_query_count/version.rb
+++ b/lib/active_record_query_count/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordQueryCount
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end

--- a/test/printer_test.rb
+++ b/test/printer_test.rb
@@ -6,6 +6,7 @@ class PrinterTest < Minitest::Test
       @data = { 'users' =>
         { count: 2,
           location: { nil => { count: 2,
+                               cached_query_count: 1,
                                duration: 2.5,
                                sql: 'SELECT "users".* FROM "users" WHERE "users"."email" = $1 LIMIT $2' } } } }
     end


### PR DESCRIPTION
This pull request implements the tracking of cached ActiveRecord queries, displaying the count in both the HTML and console printer outputs. This enhancement provides developers with more accurate database performance insights, allowing for better cache optimization.

Changes include modifications to the query tracker logic to capture cached query counts and updates to the HTML and console output formats to display this information.