### PR TITLE
feat: conditionally hide messages in HTML and console based on table count and location settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you use `html` with WSL enviroment, you need to set on your enviroments varia
 
 ### Configuration options
 
-When visualizing the html table or the console output, tables with less than `ignore_table_count` will not be shown. Also, the amount of locations to show is given by `max_locations_per_table`
+When visualizing the html table or the console output, tables with less than `ignore_table_count` will not be shown. Also, the amount of locations to show is given by `max_locations_per_table`. If `max_locations_per_table` is set to 0, all locations will be displayed without any limit.
 
 ```ruby
 config.after_initialize do

--- a/assets/template_base_query_counter.html.erb
+++ b/assets/template_base_query_counter.html.erb
@@ -5,8 +5,12 @@
   <h2>Query Count Report</h2>
   <p>Total number of queries in this process: <%= total_query_count %></p>
   <p>Total time spent on queries in this process (ms): <%= total_duration_time %></p>
-  <p>Only tables with <%= ::ActiveRecordQueryCount::Configuration.ignore_table_count %> or more queries will be displayed.</p>
+  <% if ::ActiveRecordQueryCount::Configuration.ignore_table_count > 1 %>
+    <p>Only tables with <%= ::ActiveRecordQueryCount::Configuration.ignore_table_count %> or more queries will be displayed.</p>  
+  <% end %>
+  <% unless ::ActiveRecordQueryCount::Configuration.unlimited_locations_per_table? %>
   <p>The top <%= ::ActiveRecordQueryCount::Configuration.max_locations_per_table %> locations with the highest occurrences will be shown for each table.</p>
+  <% end %>
   <button id="toggleButton" onclick="toggleView()">Show Chart View</button>
   <button id="toggleColumnButton" onclick="toggleColumnContent()">Show SQL</button>
 

--- a/lib/active_record_query_count/configuration.rb
+++ b/lib/active_record_query_count/configuration.rb
@@ -19,5 +19,9 @@ module ActiveRecordQueryCount
     def self.ignore_table_count
       ENV['QUERY_COUNT_IGNORE_TABLE_COUNT'] || @@ignore_table_count
     end
+
+    def self.unlimited_locations_per_table?
+      max_locations_per_table.zero?
+    end
   end
 end

--- a/lib/active_record_query_count/printer/base.rb
+++ b/lib/active_record_query_count/printer/base.rb
@@ -19,6 +19,8 @@ module ActiveRecordQueryCount
         end
         data = data.select { |_, v| v[:count] >= Configuration.ignore_table_count }
         data = data.sort_by { |_, v| -v[:count] }.each do |_category, info|
+          next if Configuration.max_locations_per_table.zero?
+
           info[:location] = info[:location].sort_by do |_, detail|
             -detail[:count]
           end.first(Configuration.max_locations_per_table).to_h

--- a/lib/active_record_query_count/printer/console.rb
+++ b/lib/active_record_query_count/printer/console.rb
@@ -11,8 +11,12 @@ module ActiveRecordQueryCount
         data = filter_data(@data)
         puts '[ActiveRecordQueryCount] Query count per table:'.colorize(:blue)
         puts "Total query count: #{data.values.sum { |v| v[:count] }}\n\n"
-        puts "All tables with less than #{Configuration.ignore_table_count} queries are ignored. \n\n"
-        puts "For each table, the top #{Configuration.max_locations_per_table} locations with the most queries will be shown.\n\n"
+        if Configuration.ignore_table_count > 1
+          puts "All tables with less than #{Configuration.ignore_table_count} queries are ignored. \n\n"
+        end
+        unless Configuration.unlimited_locations_per_table?
+          puts "For each table, the top #{Configuration.max_locations_per_table} locations with the most queries will be shown.\n\n"
+        end
         data.each do |category, info|
           puts "Table #{category.colorize(:cyan)}"
           puts "  Total query count: #{info[:count].to_s.colorize(:blue)}"

--- a/test/printer_test.rb
+++ b/test/printer_test.rb
@@ -3,12 +3,18 @@ require 'test_helper'
 class PrinterTest < Minitest::Test
   context 'printing methods' do
     setup do
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = 4
+      ActiveRecordQueryCount::Configuration.ignore_table_count = 1
       @data = { 'users' =>
-        { count: 2,
-          location: { nil => { count: 2,
-                               cached_query_count: 1,
-                               duration: 2.5,
-                               sql: 'SELECT "users".* FROM "users" WHERE "users"."email" = $1 LIMIT $2' } } } }
+      { count: 2,
+        location: { 'location_1' => { count: 2,
+                                      cached_query_count: 0,
+                                      duration: 2.5,
+                                      sql: 'SELECT "users".* FROM "users" WHERE "users"."email" = $1 LIMIT $2' },
+                    'location_2' => { count: 2,
+                                      cached_query_count: 1,
+                                      duration: 2.5,
+                                      sql: 'SELECT "users".* FROM "users" WHERE "users"."email" = $1 LIMIT $2' } } } }
     end
 
     should 'print html output without errors' do
@@ -23,6 +29,82 @@ class PrinterTest < Minitest::Test
 
     should 'print console output without errors' do
       ActiveRecordQueryCount::Printer::Console.new(data: @data).print
+    end
+
+    # test ignore_table_count #
+    should 'hide the message in html when ignore_table_count is 1 or less' do
+      threshold = 1
+      ActiveRecordQueryCount::Configuration.ignore_table_count = threshold
+      message = "Only tables with #{threshold} or more queries will be displayed."
+      assert_html_message_presence(@data, message, false)
+    end
+
+    should 'display the message in html when ignore_table_count is greater than 1' do
+      threshold = 2
+      ActiveRecordQueryCount::Configuration.ignore_table_count = threshold
+      message = "Only tables with #{threshold} or more queries will be displayed."
+      assert_html_message_presence(@data, message, true)
+    end
+
+    should 'hide display the message in console when ignore_table_count is 1 or less' do
+      threshold = 1
+      ActiveRecordQueryCount::Configuration.ignore_table_count = threshold
+      message = "All tables with less than #{threshold} queries are ignored."
+      assert_console_message_presence(@data, message, false)
+    end
+
+    should 'display the message in console when ignore_table_count is greater than 1' do
+      threshold = 2
+      ActiveRecordQueryCount::Configuration.ignore_table_count = threshold
+      message = "All tables with less than #{threshold} queries are ignored."
+      assert_console_message_presence(@data, message, true)
+    end
+
+    # test max_locations_per_table #
+    should 'hide the message in html when max_locations_per_table is 0' do
+      threshold = 0
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      message = "The top #{threshold} locations with the highest occurrences will be shown for each table."
+      assert_html_message_presence(@data, message, false)
+    end
+
+    should 'display the message in html when max_locations_per_table is greater than 0' do
+      threshold = 1
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      message = "The top #{threshold} locations with the highest occurrences will be shown for each table."
+      assert_html_message_presence(@data, message, true)
+    end
+
+    should 'not display the message in console when max_locations_per_table is 0' do
+      threshold = 0
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      message = "For each table, the top #{threshold} locations with the most queries will be shown."
+      assert_console_message_presence(@data, message, false)
+    end
+
+    should 'display the message in console when max_locations_per_table is greater than 0' do
+      threshold = 1
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      message = "For each table, the top #{threshold} locations with the most queries will be shown."
+      assert_console_message_presence(@data, message, true)
+    end
+
+    should 'display all file in html when max_locations_per_table is 0' do
+      threshold = 0
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      occurrences = query_counter_report_div(@data).scan('location_').count
+      # Each location appears twice in the HTML, once inside the <table id="queryTable"> and once inside the <script>.
+      assert_equal(4, occurrences)
+    end
+
+    should 'display all file location in console when max_locations_per_table is 0' do
+      threshold = 0
+      ActiveRecordQueryCount::Configuration.max_locations_per_table = threshold
+      output = capture_stdout do
+        ActiveRecordQueryCount::Printer::Console.new(data: @data).print
+      end
+      occurrences = output.scan('File location: location_').count
+      assert_equal(2, occurrences)
     end
   end
 end


### PR DESCRIPTION
This PR introduces conditional logic to hide messages in HTML and console based on the configurations of `ignore_table_count`and `max_locations_per_table`.

## Changes made:
### HTML updates:

The message about displaying tables with a minimum number of queries is now conditionally displayed based on the value of `ignore_table_count`.
### Console updates:

Similarly, the message in the console about ignored tables is conditionally shown or hidden based on the value of `ignore_table_count`.
### Data processing logic:

Updated the logic to handle `max_locations_per_table` configurations. If `max_locations_per_table` is set to 0, all locations will be shown, and the message related to the locations will be hidden.